### PR TITLE
[sailfish-access-control] Use C prototypes in C sources. Fixes JB#57726

### DIFF
--- a/glib/sailfishaccesscontrol.c
+++ b/glib/sailfishaccesscontrol.c
@@ -31,7 +31,7 @@
 
 GHashTable *s_groups = NULL;
 
-static void ensure_groups_validity()
+static void ensure_groups_validity(void)
 {
     struct stat buf;
     time_t new_mtime = 0;
@@ -108,7 +108,7 @@ bool sailfish_access_control_hasgroup(uid_t uid, const char *group_name)
     return false;
 }
 
-uid_t sailfish_access_control_systemuser_uid()
+uid_t sailfish_access_control_systemuser_uid(void)
 {
     struct group *grp = getgrnam(SAILFISH_SYSTEM_GROUP);
     struct passwd *pw;

--- a/glib/sailfishaccesscontrol.h
+++ b/glib/sailfishaccesscontrol.h
@@ -30,7 +30,7 @@ extern "C" {
 #pragma GCC visibility push(default)
 
 bool sailfish_access_control_hasgroup(uid_t uid, const char *group_name);
-uid_t sailfish_access_control_systemuser_uid();
+uid_t sailfish_access_control_systemuser_uid(void);
 
 #pragma GCC visibility pop
 


### PR DESCRIPTION
Using sailfish-access-control from C project leads to warnings like:
  function declaration isn’t a prototype [-Wstrict-prototypes]
  uid_t sailfish_access_control_systemuser_uid();

While such prototype is valid C++, in C it should have a void arg.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>