### PR TITLE
avoid passing incompatible pointer type argument

### DIFF
--- a/glib/sailfishaccesscontrol.c
+++ b/glib/sailfishaccesscontrol.c
@@ -92,7 +92,7 @@ bool sailfish_access_control_hasgroup(uid_t uid, const char *group_name)
     ensure_groups_validity();
 
     if (!s_groups)
-        s_groups = g_hash_table_new_full(NULL, NULL, NULL, destroy_group_list);
+        s_groups = g_hash_table_new_full(NULL, NULL, NULL, (GDestroyNotify)destroy_group_list);
 
     groups = g_hash_table_lookup(s_groups, GINT_TO_POINTER(uid));
     if (!groups)


### PR DESCRIPTION
It seems manjaro changed default cflags and I am not able to compile sailfish-access-control anymore:
```
Compile Dynamic: sailfishaccesscontrol.c
sailfishaccesscontrol.c: In function 'sailfish_access_control_hasgroup':
sailfishaccesscontrol.c:95:60: error: passing argument 4 of 'g_hash_table_new_full' from incompatible pointer type [-Wincompatible-pointer-types]
   95 |         s_groups = g_hash_table_new_full(NULL, NULL, NULL, destroy_group_list);
      |                                                            ^~~~~~~~~~~~~~~~~~
      |                                                            |
      |                                                            void (*)(GSList *) {aka void (*)(struct _GSList *)}
In file included from /usr/include/glib-2.0/glib.h:52,
                 from sailfishaccesscontrol.c:24:
/usr/include/glib-2.0/glib/ghash.h:66:61: note: expected 'GDestroyNotify' {aka 'void (*)(void *)'} but argument is of type 'void (*)(GSList *)' {aka 'void (*)(struct _GSList *)'}
   66 |                                             GDestroyNotify  value_destroy_func);
      |                                             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
make: *** [Makefile:104: sailfishaccesscontrol.pic.o] Error 1
```